### PR TITLE
Generator config adjustments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
                     <removeOldOutput>true</removeOldOutput>
                     <serializable>true</serializable>
                     <initializeCollections>false</initializeCollections>
+                    <inclusionLevel>NON_EMPTY</inclusionLevel>
                     <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
                     <targetPackage>org.entur.gbfs</targetPackage>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
                     <serializable>true</serializable>
                     <initializeCollections>false</initializeCollections>
                     <inclusionLevel>NON_EMPTY</inclusionLevel>
+                    <generateBuilders>true</generateBuilders>
                     <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
                     <targetPackage>org.entur.gbfs</targetPackage>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
                     </formatTypeMapping>
                     <removeOldOutput>true</removeOldOutput>
                     <serializable>true</serializable>
+                    <initializeCollections>false</initializeCollections>
                     <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
                     <targetPackage>org.entur.gbfs</targetPackage>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,6 @@
                     <removeOldOutput>true</removeOldOutput>
                     <serializable>true</serializable>
                     <initializeCollections>false</initializeCollections>
-                    <inclusionLevel>NON_EMPTY</inclusionLevel>
                     <generateBuilders>true</generateBuilders>
                     <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
                     <targetPackage>org.entur.gbfs</targetPackage>


### PR DESCRIPTION
1. Collections were previously initialised. This caused optional lists that were null in the source to become empty lists.
2. ~~Setting inclusion level to NON_EMPTY avoids problem of parsing empty strings into, well ,empty strings. It's almost always better to leave these fields as null. The same goes for lists.~~
3. Builders for types makes it more convenient to write mappers.